### PR TITLE
Fix build for version 0.7.0

### DIFF
--- a/0.7.0/Dockerfile
+++ b/0.7.0/Dockerfile
@@ -22,11 +22,13 @@ RUN dnf install -y \
       zlib-devel \
       make
 
-COPY --from=build Python-3.10.5 Python
-RUN cd Python \
+COPY --from=build Python-3.10.5 python-dist
+RUN cd python-dist \
     && ./configure --enable-optimizations \
     && make -j 4 \
-    && make altinstall
+    && make -j 4 altinstall \
+    && cd .. \
+    && rm -rf python-dist
 
 # Per the tkmatrix docs, some dependencies must be individually installed
 # prior to installing kmatrix itself. Version numbers for these packages are

--- a/0.7.0/Dockerfile
+++ b/0.7.0/Dockerfile
@@ -1,7 +1,12 @@
 FROM rockylinux:8
 
+# This version of tkmatrix requires Python 3.10 which is not avilible
+# via the dnf package manager. Instead, we install some extra system
+# dependencies and compile Python from source.
+
 RUN dnf install -y \
       gcc \
+      gcc-c++ \
       xz \
       findutils \
       openssl-devel \

--- a/0.7.0/Dockerfile
+++ b/0.7.0/Dockerfile
@@ -1,19 +1,34 @@
 FROM rockylinux:8
 
 RUN dnf install -y \
-      gcc-gfortran \
-      python310 \
-      python310-devel
+      gcc \
+      xz \
+      findutils \
+      openssl-devel \
+      bzip2-devel \
+      libffi-devel \
+      zlib-devel \
+      wget \
+      make \
+      gcc-gfortran
+
+RUN wget https://www.python.org/ftp/python/3.10.5/Python-3.10.5.tar.xz \
+    && tar -xf Python-3.10.5.tar.xz \
+    && cd Python-3.10.5 \
+    && ./configure --enable-optimizations \
+    && make -j 4 \
+    && make altinstall
 
 # Per the tkmatrix docs, some dependencies must be individually installed
 # prior to installing kmatrix itself. Version numbers for these packages are
 # pinned to the value defined in the requirements file.
 
+ENV PIP_ROOT_USER_ACTION=ignore
 COPY requirements.txt requirements.txt
-RUN pip3 install numpy==1.23.5 && \
-    pip3 install ellc==1.8.5 && \
-    pip3 install -r requirements.txt && \
-    pip3 install tkmatrix==0.7.0 
+RUN pip3.10 install numpy==1.23.5 && \
+    pip3.10 install ellc==1.8.5 && \
+    pip3.10 install -r requirements.txt && \
+    pip3.10 install tkmatrix==0.7.0
 
 RUN mkdir tkm
 WORKDIR /tkm

--- a/0.7.0/Dockerfile
+++ b/0.7.0/Dockerfile
@@ -1,25 +1,29 @@
-FROM rockylinux:8
-
 # This version of tkmatrix requires Python 3.10 which is not avilible
 # via the dnf package manager. Instead, we install some extra system
 # dependencies and compile Python from source.
 
+FROM rockylinux:8 as build
+
+RUN dnf install -y wget xz
+
+RUN wget https://www.python.org/ftp/python/3.10.5/Python-3.10.5.tar.xz \
+ && tar -xf Python-3.10.5.tar.xz
+
+FROM rockylinux:8
+
 RUN dnf install -y \
       gcc \
       gcc-c++ \
-      xz \
+      gcc-gfortran \
       findutils \
       openssl-devel \
       bzip2-devel \
       libffi-devel \
       zlib-devel \
-      wget \
-      make \
-      gcc-gfortran
+      make
 
-RUN wget https://www.python.org/ftp/python/3.10.5/Python-3.10.5.tar.xz \
-    && tar -xf Python-3.10.5.tar.xz \
-    && cd Python-3.10.5 \
+COPY --from=build Python-3.10.5 Python
+RUN cd Python \
     && ./configure --enable-optimizations \
     && make -j 4 \
     && make altinstall


### PR DESCRIPTION
Changes include:
  - Manually building and installing python 3.10 (it's not availible via `dnf`)
  - Installing some additional system dependencies (mostly to support the python install process)

I used a multi-stage build to help keep the image size down. Honestly, the impact is minimal but better than nothing.